### PR TITLE
Fix liburing config tests to use PkgConfig, and add missing liburing dependency.

### DIFF
--- a/ports/qtbase/fix-liburing-config-test.patch
+++ b/ports/qtbase/fix-liburing-config-test.patch
@@ -1,0 +1,32 @@
+diff --git a/src/corelib/CMakeLists.txt b/src/corelib/CMakeLists.txt
+index 1ca9728..b9f5d67 100644
+--- a/src/corelib/CMakeLists.txt
++++ b/src/corelib/CMakeLists.txt
+@@ -754,10 +754,10 @@ qt_internal_extend_target(Core CONDITION QCC
+ )
+ 
+ qt_internal_extend_target(Core CONDITION QT_FEATURE_liburing
+     SOURCES
+         io/qioring.cpp io/qioring_linux.cpp io/qioring_p.h
+     LIBRARIES
+-        uring
++        PkgConfig::Liburing
+ )
+ 
+ qt_internal_extend_target(Core CONDITION QT_FEATURE_windows_ioring
+diff --git a/src/corelib/configure.cmake b/src/corelib/configure.cmake
+index d7ec27c..170e433 100644
+--- a/src/corelib/configure.cmake
++++ b/src/corelib/configure.cmake
+@@ -405,10 +405,10 @@ int main(void)
+ ")
+ 
+ # liburing
+ qt_config_compile_test(liburing
+     LABEL "liburing"
+-    LIBRARIES uring
++    LIBRARIES PkgConfig::Liburing
+     CODE
+ "#include <liburing.h>
+ 
+ int main(void)

--- a/ports/qtbase/portfile.cmake
+++ b/ports/qtbase/portfile.cmake
@@ -25,6 +25,7 @@ set(${PORT}_PATCHES
         macdeployqt-symlinks.patch
         moltenvk.patch
         fix-ioring-32bit.patch
+        fix-liburing-config-test.patch
         fix-libresolv-test.patch
         use_inotify_on_freebsd.patch
         silence-winrtbase-coroutine-warnings.diff

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -394,6 +394,10 @@
       "supports": "linux | windows",
       "dependencies": [
         {
+          "name": "liburing",
+          "platform": "linux"
+        },
+        {
           "name": "qtbase",
           "default-features": false,
           "features": [

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "57528b99327a9398805fd7b90d422202bac3535c",
+      "git-tree": "83252e7af43b3499a6dacee1db87151ae49eb053",
       "version": "6.11.1",
       "port-version": 0
     },


### PR DESCRIPTION
This change was written by GPT 5.4 and seems at least plausible.